### PR TITLE
Переполняется integer при большом uptime системы.

### DIFF
--- a/Lab3D.dpr
+++ b/Lab3D.dpr
@@ -31,7 +31,7 @@ var
   B  : Bitmap;
   ws : cardinal;
   wasPhys : boolean = false;
-  predT : integer = 0;
+  predT : cardinal = 0;
   procT : integer = 0;
 
   prFor   : boolean = false;
@@ -114,7 +114,7 @@ end;
 
 procedure TimerProc;
 var
-  T, dT : integer;
+  T, dT : cardinal;
 const Delta = 15;
 begin
   T := GetTickCount;


### PR DESCRIPTION
Значение GetTickCount сохраняется в знаковой переменной. При uptime больше 25 дней (0x7fffffff/1000/3600/24) значение получается отрицательным, dT тоже и код физики не вызывается.

Заменил integer на cardinal